### PR TITLE
Fix checking collateral rate with a dust debt

### DIFF
--- a/contracts/FantomMint.sol
+++ b/contracts/FantomMint.sol
@@ -121,16 +121,13 @@ contract FantomMint is FantomMintBalanceGuard, FantomMintCollateral, FantomMintD
         return 10**uint256(IFantomMintTokenRegistry(addressProvider.getTokenRegistry()).priceDecimals(_token));
     }
 
-    // tokenValue calculates the value of the given amount of the token specified.
-    // The value is returned in given referential tokens (fUSD).
-    // Implements tokenValue() abstract function of the underlying storage contracts.
-    function tokenValue(address _token, uint256 _amount) public view returns (uint256) {
-        // do we have a reason to calculate anything?
-        if (0 == _amount) {
-            return 0;
-        }
+    // collateralTokenValue calculates the value of the given collateral amount of the token specified.
+    function collateralTokenValue(address _token, uint256 _amount) public view returns (uint256) {
+        return IFantomDeFiTokenStorage(addressProvider.getCollateralPool()).tokenValue(_token, _amount);
+    }
 
-        // calculate the value using price Oracle access
-        return _amount.mul(getPrice(_token)).div(getPriceDigitsCorrection(_token));
+    // debtTokenValue calculates the value of the given debt amount of the token specified.
+    function debtTokenValue(address _token, uint256 _amount) public view returns (uint256) {
+        return IFantomDeFiTokenStorage(addressProvider.getDebtPool()).tokenValue(_token, _amount);
     }
 }

--- a/contracts/interfaces/IFantomDeFiTokenStorage.sol
+++ b/contracts/interfaces/IFantomDeFiTokenStorage.sol
@@ -3,6 +3,9 @@ pragma solidity ^0.5.0;
 // IFantomDeFiTokenStorage defines the interface to token storage contract
 // used by the DeFi protocol to manage collateral and debt pools.
 interface IFantomDeFiTokenStorage {
+    // tokenValue returns the value of the given amount of the token specified.
+    function tokenValue(address _token, uint256 _amount) external view returns (uint256);
+
     // total returns the total value of all the tokens registered inside the storage.
     function total() external view returns (uint256);
 

--- a/contracts/modules/FantomMintBalanceGuard.sol
+++ b/contracts/modules/FantomMintBalanceGuard.sol
@@ -59,8 +59,11 @@ contract FantomMintBalanceGuard is FantomMintErrorCodes, IFantomMintBalanceGuard
     // collateralValueOf (abstract) returns the value of account collateral.
     function collateralValueOf(address _account) public view returns (uint256);
 
-    // tokenValue (abstract) calculates the value of the given amount of the token specified.
-    function tokenValue(address _token, uint256 _amount) public view returns (uint256);
+    // debtTokenValue (abstract) calculates the value of the given debt amount of the token specified.
+    function debtTokenValue(address _token, uint256 _amount) public view returns (uint256);
+
+    // collateralTokenValue (abstract) calculates the value of the given collateral amount of the token specified.
+    function collateralTokenValue(address _token, uint256 _amount) public view returns (uint256);
 
     // -------------------------------------------------------------
     // Collateral to debt ratio checks below
@@ -90,14 +93,14 @@ contract FantomMintBalanceGuard is FantomMintErrorCodes, IFantomMintBalanceGuard
     // without breaking collateral to debt ratio rule.
     function collateralCanDecrease(address _account, address _token, uint256 _amount) public view returns (bool) {
         // collateral to debt ratio must be valid after collateral decrease
-        return isCollateralSufficient(_account, tokenValue(_token, _amount), 0, collateralLowestDebtRatio4dec);
+        return isCollateralSufficient(_account, collateralTokenValue(_token, _amount), 0, collateralLowestDebtRatio4dec);
     }
 
     // debtCanIncrease checks if the specified amount of debt can be added to the account
     // without breaking collateral to debt ratio rule.
     function debtCanIncrease(address _account, address _token, uint256 _amount) public view returns (bool) {
         // collateral to debt ratio must be valid after debt increase
-        return isCollateralSufficient(_account, 0, tokenValue(_token, _amount), collateralLowestDebtRatio4dec);
+        return isCollateralSufficient(_account, 0, debtTokenValue(_token, _amount), collateralLowestDebtRatio4dec);
     }
 
     // rewardCanClaim checks if the account can claim accumulated rewards


### PR DESCRIPTION
Round debt value up to prevent:
- minting a dust amount while having no deposit
- full withdrawing while having a non-zero dust debt