### PR TITLE
edit-boo

### DIFF
--- a/docs/fip-001.md
+++ b/docs/fip-001.md
@@ -120,7 +120,7 @@ Example: The collateral factor for FTM is 50%, if the price of FTM is considered
 | sFTMX | 50% | 10m |
 | wFTM | 50% | 10m |
 | sFTM | 30% | 10m |
-| BOO | 10% | 1m |
+| BOO | 40% | 3m |
 | BEETS | 10% | 1m |
 | SPIRIT | 10% | 1m |
 | LQDR | 10% | 1m |


### PR DESCRIPTION
We propose to raise the % of BOO From 10% to 40% and the cap from 1m to 3m.

Just in case you are somehow not aware, the Chainlink Oracle for BOO can be found here https://ftmscan.com/address/0xc8c80c17f05930876ba7c1dd50d9186213496376

For comparisons:
xBOO has been on abra for many months through extreme volatility resulting in no bad debt, at 70% LTV (Not using Chainlink), it also has a 3m cap on abra.
BOO is on scream.sh at 45% using Chainlink (soon to be raised to 65%)
BOO is on granary.finance at 65% usuing Chainlink.